### PR TITLE
Try/catching existing, but bad, API keys

### DIFF
--- a/marta/api.py
+++ b/marta/api.py
@@ -43,10 +43,11 @@ def get_trains(line=None, station=None, destination=None, api_key=None):
     """
     endpoint = '{}{}?apikey={}'.format(_BASE_URL, _TRAIN_PATH, api_key)
     response = requests.get(endpoint)
-    try:
-        data = loads(response.text)
-    except JSONDecodeError:
+
+    if response.status_code == 401 or response.status_code == 403:
         raise APIKeyError('Your API key seems to be invalid. Try visiting {}.'.format(endpoint))
+
+    data = loads(response.text)
     trains = [Train(t) for t in data]
 
     trains = [t for t in trains if

--- a/marta/api.py
+++ b/marta/api.py
@@ -1,6 +1,6 @@
 import requests
 import requests_cache
-from json import loads
+from json import loads, JSONDecodeError
 from os import getenv
 from functools import wraps
 
@@ -41,8 +41,12 @@ def get_trains(line=None, station=None, destination=None, api_key=None):
     :param api_key (str): API key to override environment variable
     :return: list of Train objects
     """
-    response = requests.get('{}{}?apikey={}'.format(_BASE_URL, _TRAIN_PATH, api_key))
-    data = loads(response.text)
+    endpoint = '{}{}?apikey={}'.format(_BASE_URL, _TRAIN_PATH, api_key)
+    response = requests.get(endpoint)
+    try:
+        data = loads(response.text)
+    except JSONDecodeError:
+        raise APIKeyError('Your API key seems to be invalid. Try visiting {}.'.format(endpoint))
     trains = [Train(t) for t in data]
 
     trains = [t for t in trains if

--- a/marta/api.py
+++ b/marta/api.py
@@ -9,7 +9,7 @@ from .vehicles import Bus, Train
 
 _API_KEY = getenv('MARTA_API_KEY')
 _CACHE_EXPIRE = int(getenv('MARTA_CACHE_EXPIRE', 30))
-_BASE_URL = 'http://developer.itsmarta.com/'
+_BASE_URL = 'http://developer.itsmarta.com'
 _TRAIN_PATH = '/RealtimeTrain/RestServiceNextTrain/GetRealtimeArrivals'
 _BUS_PATH = '/BRDRestService/RestBusRealTimeService/GetAllBus'
 _BUS_ROUTE_PATH = '/BRDRestService/RestBusRealTimeService/GetBusByRoute/'

--- a/marta/exceptions.py
+++ b/marta/exceptions.py
@@ -1,5 +1,7 @@
 class APIKeyError(Exception):
     """Exception thrown for a missing API key"""
-    def __init__(self):
-        message = 'API Key is missing. Please set MARTA_API_KEY or use api_key kwarg.'
+    def __init__(self, message=None):
+
+        if not message:
+            message = 'API Key is missing. Please set MARTA_API_KEY or use api_key kwarg.'
         super(Exception, self).__init__(message)


### PR DESCRIPTION
This was the first working result I found after finding the same thing you did -- the Python bindings for the MARTA API seem old and unloved. I'm working with @gt-big-data on a MARTA project and I found your pull request. It seems to be everything I need to teach basic scraping and data aggregation -- thanks for your work!

Since I registered for my API key pretty late at night, and because (I assume, based on the non-instant 24-hour turnaround on new keys) they're human approved, I kept getting a JSON parse error when calling get_trains. When I put the actual API endpoint into a browser, I saw what the issue was:

![A nice HTML response](https://user-images.githubusercontent.com/25358963/45339440-87861780-b560-11e8-99f6-6b83894f5baf.png)

Their request error is an HTML page. Rather than include Beautiful Soup or some other parsing library, I thought it'd be enough to raise an APIKeyError when the response fails.
